### PR TITLE
Move comment inside code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ Zmin, Zmax = extrema(Z)
 ```
 
 ## 3. Create a checkerboard 8x8 matrix using the tile function
-# numpy's tile equal to repmat
 
 ```jl
+# numpy's tile equal to repmat
 Z = repmat([0 1;1 0],4,4)
 ```
 


### PR DESCRIPTION
I think this note about numpy-julia function equivalence might belong inside the code block rather than as a top-level heading?
